### PR TITLE
Fix to translate faq immediately upon manual language selection

### DIFF
--- a/webroot/js/locales.faq.js
+++ b/webroot/js/locales.faq.js
@@ -16,10 +16,10 @@ function loadFaq() {
     var locale = Cookies.get("locale") || getBrowserLocale();
     
     // first look for a translated faq
-    $.get('./locales/faq.' + locale + '.md', function(md){
+    $.get('./locales/faq.' + locale + '.md', function(md) {
         $('.doc').html(new showdown.Converter().makeHtml(md));  
-    }).fail(function(md){ // if no translation - fail back
-        $.get('faq.md', function(md){
+    }).fail(function() { // if no translation - fail back
+        $.get('faq.md', function(md) {
             $('.doc').html(new showdown.Converter().makeHtml(md));  
         });
     });

--- a/webroot/js/locales.js
+++ b/webroot/js/locales.js
@@ -38,4 +38,6 @@ function changeLocale(locale) {
             Cookies.remove('locale');
         }
     }
+
+    $(window).trigger("languagechange");
 }


### PR DESCRIPTION
Fix for https://github.com/Chia-Network/website/issues/41.

Trigger the `languagechange` event from `changeLocale` so that the faq page script knows to load the newly selected language.
  