### PR TITLE
Fix index.html and update Japanese translations

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -47,7 +47,7 @@
   <body class="layout">
     <div class="page js-page">
       <div id="main-wrapper">
-      
+
 <!--nav id="navbar_homepage" class="navbar navbar-light bg-faded">
         <a class="navbar-brand" href="/">
           <img src="../images/chia-logo.svg" class="logo">
@@ -70,20 +70,20 @@
         <span class="navbar-toggler-icon"></span>
         </button>
         </collapsebutton>
-              
+
               <div class="collapse navbar-collapse" id="navbarNav">
                 <a class="navbar-brand" href="/">
                 <img src="../images/chia-logo.svg" class="logo">
               </a>
               <ul class="navbar-nav ml-auto">
                 <li class="nav-item">
-                  <a class="nav-link disabled" href="/news/index.html">News</a>
+                  <a data-l10n-id="news" class="nav-link disabled" href="/news/index.html">News</a>
                 </li>
                 <li class="nav-item">
-                  <a class="nav-link disabled" href="/faq/index.html">FAQ</a>
+                  <a data-l10n-id="faq" class="nav-link disabled" href="/faq/index.html">FAQ</a>
                 </li>
                 <li class="nav-item">
-                  <button type="button" class="btn btn-primary btn-lg" ><a class="jobs_link" href="#jobs">We're hiring!</a></button>
+                  <button type="button" class="btn btn-primary btn-lg" ><a data-l10n-id="hiring" class="jobs_link" href="#jobs">We're hiring!</a></button>
 
                 </li>
               </ul>
@@ -113,12 +113,12 @@
         <div class="wrap container-fluid" id="announcements">
           <div class="row">
             <div class="col">
-              <h4 data-l10n-id="Ready to invest?">Ready to invest?</h4>
+              <h4 data-l10n-id="ready-to-invenst">Ready to invest?</h4>
               <h2 data-l10n-id="sell-plan">Chia will be available to the public in the summer of 2018</h2>
             </div>
             <div class="col">
               <div class="centered">
-                <button type="button" class="btn btn-primary btn-lg" ><a class="button-link" target="blank" href="https://groups.google.com/a/chia.network/forum/#!forum/announce">Sign up for announcements</a></button>
+                <button data-l10n-id="subscribe" type="button" class="btn btn-primary btn-lg" ><a class="button-link" target="blank" href="https://groups.google.com/a/chia.network/forum/#!forum/announce">Sign up for announcements</a></button>
               </div>
             </div>
           </div>
@@ -140,36 +140,36 @@
                 <div class="info-box">
                   <p>
                     <ul>
-                      <li><h4>Talks and Papers</h4></li>
-                      
+                      <li data-l10n-id="talks-and-papers"><h4>Talks and Papers</h4></li>
+
                        <li>Bram Cohen giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=2Zlcgt8FVz4">talk</a> at Stanford about stopping grinding attacks in Proofs of Space. </li>
 
-                       <li>Bram Cohen giving a
+                       <li data-l10n-id="bpase-2018-first">Bram Cohen giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=iqxkO7C-cyk&feature=youtu.be">talk</a> at BPASE 2018 based on this very <a href="https://eprint.iacr.org/2017/893">technical paper</a> about Proofs of Space with <a href="https://view.publitas.com/chia-network/pbase18slides/" target="blank">slides</a> by Hamza Abusalah. </li>
-                        <!--li data-l10n-id="james-talk">James Prestwich giving a 
+                        <!--li data-l10n-id="james-talk">James Prestwich giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=xe5d-Fn1yoo&feature=youtu.be">talk </a> at SF Cryptocurrency Devs Seminar about Chia Script and BLS Signatures with
                         <a target="blank" href="https://view.publitas.com/chia-network/chia-script/">slides</a>.</li-->
-                        <li>Ben Fisch giving a
+                        <li data-l10n-id="bpase-2018-second">Ben Fisch giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=qUoagL7OZ1k&feature=youtu.be">talk</a> at BPASE 2018 on Verifiable Delay Functions.</li>
                       <li data-l10n-id="recent-talk">Bram Cohen's
                         <a target="blank" href="https://www.facebook.com/BerkeleyBlockchain/videos/2006069823011271/">talk at Blockchain at Berkeley</a> (starts about 20:00) with
                         <a target="blank" href="https://view.publitas.com/chia-network/chia-1/">slides</a>.</li>
                       <li data-l10n-id="older-talk">Bram Cohen's
-                        
+
                         <!-- Updated for conflict "#115: #112 : Link to articles for news logo on homepage" -->
-                        <!-- 
+                        <!--
                         <a href="https://www.youtube.com/watch?v=aYG0NxoG7yw">talk at BPASE 2017</a> with
                         <a href="https://cyber.stanford.edu/sites/default/files/bramcohen.pdf">slides</a>.</li>
                         -->
-                        
+
                         <a target="blank" href="https://www.youtube.com/watch?v=aYG0NxoG7yw">talk at BPASE 2017</a> with
                         <a target="blank" href="https://cyber.stanford.edu/sites/default/files/bramcohen.pdf">slides</a>.</li>
 
-                         <li >Bram Cohen giving a
+                         <li data-l10n-id="scaling-bitcoin">Bram Cohen giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=zZaB4hM8SQ4">talk</a> at SF Bitcoin Devs Seminar about data structures for scalling Bitcoin with <a target="blank" href="https://view.publitas.com/chia-network/bitcoin_data_structures/">slides </a>and<a target="blank" href="https://github.com/bramcohen/MerkleSet"> code</a>.</li>
 
-                        <li >Bram Cohen giving a
+                        <li data-l10n-id="waste-talk">Bram Cohen giving a
                         <a target="blank" href="https://www.youtube.com/watch?v=zZaB4hM8SQ4">talk </a>at SF Bitcoin Devs Seminar about removing waste from cryptocurrencies.</li>
                     </ul>
                   </p>
@@ -179,7 +179,7 @@
                 <div class="info-box">
                   <p>
                     <ul>
-                      <li><h4>News and Information</h4></li>
+                      <li data-l10n-id="news-and-info"><h4>News and Information</h4></li>
 
                        <li data-l10n-id="news-link">Follow the latest articles on the <a href="news/">News</a>page.</li>
                        <li data-l10n-id="faq-link">Visit our <a href="faq/">Frequently Asked Questions (FAQ)</a>to learn more!</li>
@@ -213,7 +213,7 @@
             </div>
             <div class="col-7">
                  <img src="../images/icon_about.svg">
-                <h2 data-l10n-id="About Chia">About Chia</h2>
+                <h2 data-l10n-id="about-chia">About Chia</h2>
                 <p data-l10n-id="about-detail"> Chia Network is a San Francisco-based company focused on improving crypto-currency infrastructure. Our CEO, Bram Cohen, famously invented BitTorrent: the first modern decentralized network protocol and one of the inspirations for the Bitcoin
                   protocol. Our founding team has experience across the crypto-currency and finance sectors, coming from Tradehill, CryptoCorp and Lightning Labs. </p>
 

--- a/webroot/locales/app.ja.ftl
+++ b/webroot/locales/app.ja.ftl
@@ -6,9 +6,11 @@ get-chia = Get Chia
 
 community = コミュニティ
 
-about-us = 私達について
+about-chia = Chiaについて
 
-jobs = 求人
+contribute = Contribute
+
+jobs = Chiaで働く
 
 learn-more = 更に詳しく知る
 
@@ -24,44 +26,74 @@ in-the-news = Chiaに関するニュース
 // longer content sections
 get-the-latest-news = <br />最新のChiaに関するニュース
 
-mission = 私達はブロックチェーンをproofs of spaceと時間に基いて構築し暗号通貨をより無駄が少ない、より分散化された、より安全なものにします。
+mission = 私達はブロックチェーンをproofs of spaceとproofs of timeに基いて構築し暗号通貨をより無駄が少ない、より分散化された、より安全なものにします。
 
-recent-talk = <a href="https://drive.google.com/file/d/0ByHuc4xBso7TaEpWSlozWlpxcVk/view">スライド</a>を使用した
-    <a href="https://www.facebook.com/BerkeleyBlockchain/videos/2006069823011271/">最近の講演</a>(20分頃から始まります)。
+recent-talk = Bram Cohenによる<a href="https://view.publitas.com/chia-network/chia-1/">スライド</a>を使用したBerkeleyのBlockchainでの<a href="https://www.facebook.com/BerkeleyBlockchain/videos/2006069823011271/">講演</a> (20分頃から始まります)。
 
-older-talk =  <a href="https://cyber.stanford.edu/sites/default/files/bramcohen.pdf">スライド</a>を使用した
-    <a href="https://www.youtube.com/watch?v=aYG0NxoG7yw">以前の講演</a>。
-    <br />
+older-talk = Bram Cohenによる<a href="https://cyber.stanford.edu/sites/default/files/bramcohen.pdf">スライド</a>を使用したBPASE 2017での<a href="https://www.youtube.com/watch?v=aYG0NxoG7yw">講演</a>。
+
+james-talk = James Prestwichによる<a href="https://view.publitas.com/chia-network/chia-script/">スライド</a>を使用したChia ScriptとBLS SignaturesについてのSF Cryptocurrency Devsセミナーでの<a href="https://www.youtube.com/watch?v=xe5d-Fn1yoo&feature=youtu.be">講演</a>。
+
+
+scaling-bitcoin = Bram Cohenによる<a target="blank" href="https://view.publitas.com/chia-network/bitcoin_data_structures/">スライド</a>を使用したBitcoinスケーリングの為のデータ構造についてのSF Bitcoin Devsセミナーでの<a target="blank" href="https://www.youtube.com/watch?v=zZaB4hM8SQ4">講演</a>。
+
+waste-talk = Bram Cohenによる暗号通貨から無駄なものを取り除く事についてのSF Bitcoin Devsセミナーでの<a target="blank" href="https://www.youtube.com/watch?v=zZaB4hM8SQ4">講演</a>。
 
 tech-paper-link = proofs of spaceについての非常に<a href="https://eprint.iacr.org/2017/893">技術的な論文</a>
 
 news-link = 最新の<a href="/news">ニュース</a>を読む。
 
-faq-link = <a href="faq/">よくある質問 (FAQ)</a>
+faq-link = <a href="faq/">よくある質問(FAQ)</a>を読んで更にChiaについて学びましょう！
 
-sell-plan = 私達は誰もがより良い電子通貨に投資できるよう、2018年にChiaを一般公開する予定です。
+sell-plan = Chiaは2018年の夏に一般公開されます。
+
+ready-to-invenst = 投資の準備はいいですか？
 
 subscribe = 詳細は<a href="https://groups.google.com/a/chia.network/forum/#!forum/announce">アナウンスリスト</a>を購読して下さい。
 
 join-keybase = ディスカッションに参加するには私達のKeybaseに参加して下さい。
 
-install-keybase = <a href="https://keybase.io/download">Keybase</a>をインストール、セットアップする
+install-keybase = <p><a href="https://keybase.io/download">Keybase</a>をインストールし、セットアップする</p>
 
-request-keybase-access = 次のコマンドをterminalで実行する:
+request-keybase-access = <p>次のコマンドをターミナルで実行する:<br> <code>keybase team request-access chia_network.public</code></p>
 
-join-announcement-list = <a href="https://groups.google.com/a/chia.network/forum/#!forum/announce">アナウンスリスト</a>に参加して最新情報を手に入れましょう。
+join-announcement-list = <a class="sub_link" href="https://groups.google.com/a/chia.network/forum/#!forum/announce">アナウンスリスト</a>に参加して最新情報を手に入れましょう。
 
 looking-to-hire = 私達は暗号研究者と協力してプロトコルの構築が出来るよう技術的才能があるプログラマを探しています。
     アルゴリズムに関する高いスキルが必要です。暗号研究の経験は必須ではありませんが、プラスになります。リモートも可能ですが、サンフランシスコで働けることはプラスになります。
-    応募するには幾つかのHackerRankチャレンジを行い、HackerRankプロフィールのリンクと履歴書を<a href="mailto:jobs@chia.network">jobs@chia.network</a>に送って下さい。
+    応募するには幾つかの<a target="blank" href="https://leetcode.com/contest/">LeetCode</a>コンテストを行い、LeetCodeプロフィールのリンクと履歴書を<a href="mailto:jobs@chia.net">jobs@chia.net</a>に送って下さい。
 
-hiring-detail = 私達は創業者(エグゼクティブアシスタント/オフィスマネージャー)のアシスタントを探しています。勤務地はサンフランシスコにあります。応募するには履歴書を
-    <a href="mailto:jobs@chia.network">jobs@chia.network</a>に送って下さい。
+hiring-detail = 私達は創業者(エグゼクティブアシスタント/オフィスマネージャー)のアシスタントを探しています。勤務地はサンフランシスコにあります。
+    応募するには履歴書を<a href="mailto:jobs@chia.net">jobs@chia.net</a>に送って下さい。
 
 financial-instituation-value-prop = 電子通貨は個人投資家や機関投資家からますます必要とされています。Chiaは従来の金融機関がその需要を満たすのを手助けする事が出来ます。
 
-contact-us = 詳しくは<a href="mailto:hello@chia.network">お問い合わせ</a>下さい。
+contact-us = 詳しくは<a class="sub_link" href="mailto:hello@chia.net">お問い合わせ</a>下さい。
 
 about-detail = Chia Networkはサンフランシスコに本拠を置く暗号通貨のインフラストラクチャの改善に重点を置いた企業です。私達の
     CEO、Bram Cohenは最初の近代的な分散型ネットワークプロトコルで有名なBitcoinプロトコルのインスピレーションの1つでもある
     BitTorrentを発明しました。創業チームはTradehill、CryptoCorp、Lightning Labsでの暗号通貨及び金融分野での経験があります。
+
+contribute-question = あなたはChia Networkに貢献したいデベロッパーですか？ 以下に幾つかのアイディアがあります:
+
+contribute-idea-one = <strong>既にあるIssueを修正する</strong>: <a href="https://github.com/Chia-Network/website/issues">issueトラッカー</a>はChia Networkに貢献するための近道を見つけるのに一番優れています。 修正したい問題のパッチを書き始める前に、issueに既に誰かが作業していないかを確認するためにコメントをしたほうが良いでしょう。
+
+contribute-idea-two = <strong>言語翻訳を追加する</strong>: Githubのツールを使用してウェブサイトのリポジトリをcloneし変更点をそのまま提出することをお薦めします。 私達のサイトを<a href="https://github.com/Chia-Network/website">github</a>で見てpull requestを提出して下さい。
+
+footer-language = 言語
+
+footer-contact = 連絡先
+
+footer-find-us = 私達を見つける
+
+news-and-info = <h4>ニュースと情報</h4>
+
+talks-and-papers = <h4>講演と論文</h4>
+
+bpase-2018-first = Bram Cohen givingがBPASE 2018でproofs of spaceに関する<a href="https://eprint.iacr.org/2017/893">学術論文</a>を基に<a href="https://www.youtube.com/watch?v=iqxkO7C-cyk&feature=youtu.be">講演</a>しました。<a herf=https://view.publitas.com/chia-network/pbase18slides/page/1>スライド</a>はHamza Abusalahが作成しました。
+
+bpase-2018-second = Ben FischがBPASE 2018で検証可能な遅延関数について<a href="https://www.youtube.com/watch?v=qUoagL7OZ1k&feature=youtu.be">講演</a>しました。
+
+sign-up = サインアップしてアナウンスを受け取る
+
+news = ニュース


### PR DESCRIPTION
I fixed missing `data-l10n-id` in `index.html` to apply translations correctly.
And I updated Japanese translations. (I prefer get review from @akiyoshi 'cause they opened #123 )

Also, there're still one problem. 

```
<li>Bram Cohen giving a
<a target="blank" href="https://www.youtube.com/watch?v=2Zlcgt8FVz4">talk</a> at Stanford about stopping grinding attacks in Proofs of Space. </li>
```
this section seems has no `data-l10n-id` tag and not in translation file.
I didn't add the tag id by myself. for avoid conflicting to someone else.