### PR TITLE
Fix "ready-to-invenst" typo in index.html

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -113,7 +113,7 @@
         <div class="wrap container-fluid" id="announcements">
           <div class="row">
             <div class="col">
-              <h4 data-l10n-id="ready-to-invenst">Ready to invest?</h4>
+              <h4 data-l10n-id="ready-to-invest">Ready to invest?</h4>
               <h2 data-l10n-id="sell-plan">Chia will be available to the public in the summer of 2018</h2>
             </div>
             <div class="col">


### PR DESCRIPTION
The typo caused "ready-to-invenst" to display as the text, instead of "Ready to invest?". 