### PR TITLE
fix the .news-box from the news page responsive and change images size

### DIFF
--- a/webroot/css/style.css
+++ b/webroot/css/style.css
@@ -558,7 +558,7 @@ display: inline!important;
 #news-feed-page .news-box {
   border: 1px solid #e7e7e7;
   border-radius: 3px;
-  height:207px;
+  height:auto;
   box-shadow: 0 2px 4px 0 rgba(0,0,0,0.02);
   margin: 0 auto;
   max-width: 100%;
@@ -626,7 +626,8 @@ display: inline!important;
 }
 
 #news-feed-page .image-box {
-  max-width: 95%;
+  max-width: 150px;
+  height: auto;
 }
 
 #news-feed-page .read-more-link {


### PR DESCRIPTION
New Look in different screen width:
<img width="564" alt="screen shot 2018-03-25 at 4 37 33 pm" src="https://user-images.githubusercontent.com/23219022/37879712-f81175ee-304a-11e8-9324-f21c260adb4b.png">

<img width="387" alt="screen shot 2018-03-25 at 4 38 10 pm" src="https://user-images.githubusercontent.com/23219022/37879713-fd07fe1a-304a-11e8-8e19-fba06a65f5ef.png">


